### PR TITLE
Replaces `clientId` with `client_id` when retrieving the audience

### DIFF
--- a/src/OAuth2/KeyCloakResourceServer.php
+++ b/src/OAuth2/KeyCloakResourceServer.php
@@ -172,7 +172,7 @@ class KeyCloakResourceServer implements ResourceServerInterface
         if ($token === null) {
             return null;
         }
-        $audience = $token->claims()->get('clientId');
+        $audience = $token->claims()->get('client_id');
         if (!is_string($audience)) {
             return null;
         }


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixes retrieving the audience with the correct key
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Try to request the new API with an access token created in KeyCloak

⚠️ Maybe the name differ based on the Keycloak version used, double check with QA and if this is indeed the case make a fallback instead